### PR TITLE
Fix housing market CSV header and comments

### DIFF
--- a/ILUTE/Model/Housing/HousingMarket.cs
+++ b/ILUTE/Model/Housing/HousingMarket.cs
@@ -106,7 +106,7 @@ namespace TMG.Ilute.Model.Housing
 
         // Exports columns for writing to CSV
 
-        public List<string> Headers => new List<string>() { "DwellingsSold", "HouseholdsRemaining", "DwellingsReamining", "AverageSalePrice" };
+        public List<string> Headers => new List<string>() { "DwellingsSold", "HouseholdsRemaining", "DwellingsRemaining", "AverageSalePrice" };
 
         public List<float> YearlyResults => new List<float>()
         {
@@ -195,7 +195,7 @@ namespace TMG.Ilute.Model.Housing
 
         private List<Dwelling> _monthlyBuyerCurrentDwellings;
 
-        //  Thread-safe collection of housholds that want a larger home
+        //  Thread-safe collection of households that want a larger home
 
         private ConcurrentBag<long> _demandLargerDwelling;
 
@@ -300,7 +300,7 @@ namespace TMG.Ilute.Model.Housing
             var headAge = hhld.Families.Max(f => f.Persons.Max(p => p.Age));
             var numbOfJobs = hhld.Families.Sum(f => f.Persons.Count(p => p.Jobs.Any()));
 
-            int demandCounter = 0; // Determines whether a houshold likely needs a larger dwelling
+            int demandCounter = 0; // Determines whether a household likely needs a larger dwelling
             double probMoving = RES_MOBILITY_CONSTANT;  // base parameter (M.A. Habib, 2009. pg. 46)
 
             if (jobIncrease)


### PR DESCRIPTION
## Summary
- fix CSV header typo `DwellingsRemaining`
- correct spelling of `households` in comments

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68405ca68e2083208866a172fedf235d