### PR TITLE
Fix enumeration spelling for Detached

### DIFF
--- a/ILUTE/Data/Housing/Dwelling.cs
+++ b/ILUTE/Data/Housing/Dwelling.cs
@@ -70,7 +70,7 @@ namespace TMG.Ilute.Data.Housing
 
         public enum DwellingType
         {
-            Detched = 0,
+            Detached = 0,
             Attached = 1,
             SemiDetached = 2,
             ApartmentLow = 3,

--- a/ILUTE/Model/Housing/AskingPrice.cs
+++ b/ILUTE/Model/Housing/AskingPrice.cs
@@ -198,7 +198,7 @@ namespace TMG.Ilute.Model.Housing
 
             switch (seller.Type)
             {
-                case Dwelling.DwellingType.Detched:
+                case Dwelling.DwellingType.Detached:
                     //myZone.AvgSellPriceDet
                     averageSalePriceForThisType = 300000;
                     break;

--- a/ILUTE/Model/Housing/HousingMarket.cs
+++ b/ILUTE/Model/Housing/HousingMarket.cs
@@ -417,7 +417,7 @@ namespace TMG.Ilute.Model.Housing
             var offset = Detached;
             switch (dwellingType)
             {
-                case Dwelling.DwellingType.Detched:
+                case Dwelling.DwellingType.Detached:
                     break;
                 case Dwelling.DwellingType.SemiDetached:
                     offset = SemiDetached;


### PR DESCRIPTION
## Summary
- correct spelling of `Detached` dwelling type in `Dwelling.cs`
- update usage in `AskingPrice.cs` and `HousingMarket.cs`

## Testing
- `dotnet build ILUTE/Ilute.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405c93b3448320974a9d58c251f53b