### PR TITLE
Fix null disposal in demographic models

### DIFF
--- a/ILUTE/Model/Demographic/BirthModel.cs
+++ b/ILUTE/Model/Demographic/BirthModel.cs
@@ -264,8 +264,11 @@ namespace TMG.Ilute.Model.Demographic
             {
                 GC.SuppressFinalize(this);
             }
-            RandomGenerator.Dispose();
-            RandomGenerator = null;
+            if (RandomGenerator != null)
+            {
+                RandomGenerator.Dispose();
+                RandomGenerator = null;
+            }
         }
 
         public void Dispose()

--- a/ILUTE/Model/Demographic/DeathModel.cs
+++ b/ILUTE/Model/Demographic/DeathModel.cs
@@ -174,8 +174,11 @@ namespace TMG.Ilute.Model.Demographic
             {
                 GC.SuppressFinalize(this);
             }
-            RandomGenerator.Dispose();
-            RandomGenerator = null;
+            if (RandomGenerator != null)
+            {
+                RandomGenerator.Dispose();
+                RandomGenerator = null;
+            }
         }
 
         public void Dispose()

--- a/ILUTE/Model/Demographic/Divorce.cs
+++ b/ILUTE/Model/Demographic/Divorce.cs
@@ -280,8 +280,11 @@ namespace TMG.Ilute.Model.Demographic
             {
                 GC.SuppressFinalize(this);
             }
-            RandomGenerator.Dispose();
-            RandomGenerator = null;
+            if (RandomGenerator != null)
+            {
+                RandomGenerator.Dispose();
+                RandomGenerator = null;
+            }
         }
 
         public void Dispose()

--- a/ILUTE/Model/Demographic/Immigration.cs
+++ b/ILUTE/Model/Demographic/Immigration.cs
@@ -596,8 +596,11 @@ namespace TMG.Ilute.Model.Demographic
             {
                 GC.SuppressFinalize(this);
             }
-            RandomGenerator.Dispose();
-            RandomGenerator = null;
+            if (RandomGenerator != null)
+            {
+                RandomGenerator.Dispose();
+                RandomGenerator = null;
+            }
         }
 
         public void Dispose()

--- a/ILUTE/Model/Demographic/MarriageMarket.cs
+++ b/ILUTE/Model/Demographic/MarriageMarket.cs
@@ -222,8 +222,11 @@ namespace TMG.Ilute.Model.Demographic
             {
                 GC.SuppressFinalize(this);
             }
-            _randomGenerator.Dispose();
-            _randomGenerator = null;
+            if (_randomGenerator != null)
+            {
+                _randomGenerator.Dispose();
+                _randomGenerator = null;
+            }
         }
 
         public void Dispose()

--- a/ILUTE/Model/Demographic/OutMigration.cs
+++ b/ILUTE/Model/Demographic/OutMigration.cs
@@ -88,8 +88,11 @@ namespace TMG.Ilute.Model.Demographic
             {
                 GC.SuppressFinalize(this);
             }
-            RandomGenerator.Dispose();
-            RandomGenerator = null;
+            if (RandomGenerator != null)
+            {
+                RandomGenerator.Dispose();
+                RandomGenerator = null;
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- prevent null `RandomStream` objects from causing exceptions when disposing

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472c6422f083208739b36a99f5a072