### PR TITLE
Fix disposal and rename divorce methods

### DIFF
--- a/ILUTE/Data/Demographics/Family.cs
+++ b/ILUTE/Data/Demographics/Family.cs
@@ -90,7 +90,7 @@ namespace TMG.Ilute.Data.Demographics
             }
         }
 
-        public void Divorse(Repository<Family> familyRepo)
+        public void Divorce(Repository<Family> familyRepo)
         {
             var female = FemaleHead;
             var male = MaleHead;

--- a/ILUTE/Ilute.csproj
+++ b/ILUTE/Ilute.csproj
@@ -17,8 +17,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 	  <OutputPath>..\..\..\XTMF-Dev\Modules\</OutputPath>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	  <LangVersion>latest</LangVersion>
 	  <Optimize>True</Optimize>
   </PropertyGroup>

--- a/ILUTE/Model/Demographic/Divorce.cs
+++ b/ILUTE/Model/Demographic/Divorce.cs
@@ -143,7 +143,9 @@ namespace TMG.Ilute.Model.Demographic
         {
             get
             {
-                return new List<float>() {(float)DivorceProbability / NumberOfTimes, NumberOfTimes };
+                // Guard against divide by zero when no divorces occurred
+                var probability = NumberOfTimes == 0 ? 0f : (float)DivorceProbability / NumberOfTimes;
+                return new List<float>() { probability, NumberOfTimes };
             }
         }
 
@@ -167,7 +169,7 @@ namespace TMG.Ilute.Model.Demographic
                    if (female != null && male != null && female.Spouse == male)
                    {
                        var pick = rand.Take();
-                       if (CheckIfShouldDivorse(pick, family, year))
+                        if (CheckIfShouldDivorce(pick, family, year))
                        {
                            toDivoce.Add(family);
                        }
@@ -180,7 +182,7 @@ namespace TMG.Ilute.Model.Demographic
             // After identifying all of the families to be divorced, do so.
             foreach (var family in toDivoce)
             {
-                family.Divorse(families);
+                family.Divorce(families);
             }
             log.WriteToLog("Finished divorcing all families.");
         }
@@ -188,7 +190,7 @@ namespace TMG.Ilute.Model.Demographic
         double DivorceProbability;
         int NumberOfTimes;
 
-        private bool CheckIfShouldDivorse(float pick, Family family, int currentYear)
+        private bool CheckIfShouldDivorce(float pick, Family family, int currentYear)
         {
             var female = family.FemaleHead;
             var male = family.MaleHead;
@@ -280,11 +282,8 @@ namespace TMG.Ilute.Model.Demographic
             {
                 GC.SuppressFinalize(this);
             }
-            if (RandomGenerator != null)
-            {
-                RandomGenerator.Dispose();
-                RandomGenerator = null;
-            }
+            RandomGenerator?.Dispose();
+            RandomGenerator = null;
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- fix `Dispose` pattern in `Divorce` to guard against null
- rename misspelled `Divorse` methods to `Divorce`
- avoid divide-by-zero in `YearlyResults`
- clean duplicate property in `Ilute.csproj`

## Testing
- `dotnet build ILUTE/Ilute.csproj -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684739a0d43083208a801c5107007a79