### PR TITLE
Fix disposal and rename divorce methods

### DIFF
--- a/ILUTE/Data/Demographics/Family.cs
+++ b/ILUTE/Data/Demographics/Family.cs
@@ -90,7 +90,7 @@ namespace TMG.Ilute.Data.Demographics
             }
         }
 
-        public void Divorse(Repository<Family> familyRepo)
+        public void Divorce(Repository<Family> familyRepo)
         {
             var female = FemaleHead;
             var male = MaleHead;

--- a/ILUTE/Ilute.csproj
+++ b/ILUTE/Ilute.csproj
@@ -17,8 +17,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 	  <OutputPath>..\..\..\XTMF-Dev\Modules\</OutputPath>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	  <LangVersion>latest</LangVersion>
 	  <Optimize>True</Optimize>
   </PropertyGroup>

--- a/ILUTE/Model/Demographic/BirthModel.cs
+++ b/ILUTE/Model/Demographic/BirthModel.cs
@@ -255,6 +255,16 @@ namespace TMG.Ilute.Model.Demographic
 
         public bool RuntimeValidation(ref string error)
         {
+            if (PersonRepository == null)
+            {
+                error = Name + ": missing persons repository.";
+                return false;
+            }
+            if (FamilyRepository == null)
+            {
+                error = Name + ": missing families repository.";
+                return false;
+            }
             return true;
         }
 

--- a/ILUTE/Model/Demographic/CleanupTheDead.cs
+++ b/ILUTE/Model/Demographic/CleanupTheDead.cs
@@ -109,6 +109,11 @@ namespace TMG.Ilute.Model.Demographic
 
         public bool RuntimeValidation(ref string error)
         {
+            if (Households == null)
+            {
+                error = Name + ": missing households repository.";
+                return false;
+            }
             return true;
         }
     }

--- a/ILUTE/Model/Demographic/DeathModel.cs
+++ b/ILUTE/Model/Demographic/DeathModel.cs
@@ -165,6 +165,11 @@ namespace TMG.Ilute.Model.Demographic
 
         public bool RuntimeValidation(ref string error)
         {
+            if (PersonRepository == null)
+            {
+                error = Name + ": missing persons repository.";
+                return false;
+            }
             return true;
         }
 

--- a/ILUTE/Model/Demographic/Divorce.cs
+++ b/ILUTE/Model/Demographic/Divorce.cs
@@ -143,7 +143,9 @@ namespace TMG.Ilute.Model.Demographic
         {
             get
             {
-                return new List<float>() {(float)DivorceProbability / NumberOfTimes, NumberOfTimes };
+                // Guard against divide by zero when no divorces occurred
+                var probability = NumberOfTimes == 0 ? 0f : (float)DivorceProbability / NumberOfTimes;
+                return new List<float>() { probability, NumberOfTimes };
             }
         }
 
@@ -167,7 +169,7 @@ namespace TMG.Ilute.Model.Demographic
                    if (female != null && male != null && female.Spouse == male)
                    {
                        var pick = rand.Take();
-                       if (CheckIfShouldDivorse(pick, family, year))
+                        if (CheckIfShouldDivorce(pick, family, year))
                        {
                            toDivoce.Add(family);
                        }
@@ -180,7 +182,7 @@ namespace TMG.Ilute.Model.Demographic
             // After identifying all of the families to be divorced, do so.
             foreach (var family in toDivoce)
             {
-                family.Divorse(families);
+                family.Divorce(families);
             }
             log.WriteToLog("Finished divorcing all families.");
         }
@@ -188,7 +190,7 @@ namespace TMG.Ilute.Model.Demographic
         double DivorceProbability;
         int NumberOfTimes;
 
-        private bool CheckIfShouldDivorse(float pick, Family family, int currentYear)
+        private bool CheckIfShouldDivorce(float pick, Family family, int currentYear)
         {
             var female = family.FemaleHead;
             var male = family.MaleHead;
@@ -280,11 +282,8 @@ namespace TMG.Ilute.Model.Demographic
             {
                 GC.SuppressFinalize(this);
             }
-            if (RandomGenerator != null)
-            {
-                RandomGenerator.Dispose();
-                RandomGenerator = null;
-            }
+            RandomGenerator?.Dispose();
+            RandomGenerator = null;
         }
 
         public void Dispose()

--- a/ILUTE/Model/Demographic/Immigration.cs
+++ b/ILUTE/Model/Demographic/Immigration.cs
@@ -120,6 +120,11 @@ namespace TMG.Ilute.Model.Demographic
 
             public bool RuntimeValidation(ref string error)
             {
+                if (YearlyFamilyData == null || YearlyIndividualsData == null)
+                {
+                    error = Name + ": missing yearly immigration data.";
+                    return false;
+                }
                 return true;
             }
             private Person CreatePerson(float rand, int age, int sex, int maritalStatus)
@@ -587,6 +592,21 @@ namespace TMG.Ilute.Model.Demographic
 
         public bool RuntimeValidation(ref string error)
         {
+            if (RepositoryPerson == null)
+            {
+                error = Name + ": missing persons repository.";
+                return false;
+            }
+            if (RepositoryFamily == null)
+            {
+                error = Name + ": missing families repository.";
+                return false;
+            }
+            if (RepositoryHousehold == null)
+            {
+                error = Name + ": missing households repository.";
+                return false;
+            }
             return true;
         }
 

--- a/ILUTE/Model/Demographic/InitializePopulation.cs
+++ b/ILUTE/Model/Demographic/InitializePopulation.cs
@@ -83,6 +83,16 @@ Household:
 
         public bool RuntimeValidation(ref string error)
         {
+            if (RepositoryHousehold == null)
+            {
+                error = Name + ": missing households repository.";
+                return false;
+            }
+            if (RepositoryDwellings == null)
+            {
+                error = Name + ": missing dwellings repository.";
+                return false;
+            }
             return true;
         }
 

--- a/ILUTE/Model/Demographic/MarriageMarket.cs
+++ b/ILUTE/Model/Demographic/MarriageMarket.cs
@@ -216,6 +216,21 @@ namespace TMG.Ilute.Model.Demographic
         {
         }
 
+        public bool RuntimeValidation(ref string error)
+        {
+            if (PersonRepository == null)
+            {
+                error = Name + ": missing persons repository.";
+                return false;
+            }
+            if (FamilyRepository == null)
+            {
+                error = Name + ": missing families repository.";
+                return false;
+            }
+            return true;
+        }
+
         private void Dispose(bool managed)
         {
             if (managed)

--- a/ILUTE/Model/Demographic/OutMigration.cs
+++ b/ILUTE/Model/Demographic/OutMigration.cs
@@ -201,6 +201,11 @@ namespace TMG.Ilute.Model.Demographic
 
         public bool RuntimeValidation(ref string error)
         {
+            if (Households == null)
+            {
+                error = Name + ": missing households repository.";
+                return false;
+            }
             return true;
         }
     }

--- a/ILUTE/Model/Housing/AskingPrice.cs
+++ b/ILUTE/Model/Housing/AskingPrice.cs
@@ -244,6 +244,11 @@ namespace TMG.Ilute.Model.Housing
 
         public bool RuntimeValidation(ref string error)
         {
+            if (Dwellings == null)
+            {
+                error = Name + ": missing dwellings repository.";
+                return false;
+            }
             return true;
         }
     }

--- a/ILUTE/Model/Housing/Bid.cs
+++ b/ILUTE/Model/Housing/Bid.cs
@@ -149,6 +149,11 @@ namespace TMG.Ilute.Model.Housing
 
         public bool RuntimeValidation(ref string error)
         {
+            if (Households == null)
+            {
+                error = Name + ": missing households repository.";
+                return false;
+            }
             return true;
         }
 

--- a/ILUTE/Model/Housing/HousingMarket.cs
+++ b/ILUTE/Model/Housing/HousingMarket.cs
@@ -562,6 +562,16 @@ namespace TMG.Ilute.Model.Housing
             Dispose(true);
             GC.SuppressFinalize(this);
         }
+
+        public override bool RuntimeValidation(ref string error)
+        {
+            if (DwellingRepository == null)
+            {
+                error = Name + ": missing dwelling repository.";
+                return false;
+            }
+            return base.RuntimeValidation(ref error);
+        }
         #endregion
     }
 }

--- a/ILUTE/Model/Housing/Validation/CountDwellingsByZone.cs
+++ b/ILUTE/Model/Housing/Validation/CountDwellingsByZone.cs
@@ -125,6 +125,11 @@ namespace TMG.Ilute.Model.Housing.Validation
 
         public bool RuntimeValidation(ref string error)
         {
+            if (Dwellings == null)
+            {
+                error = Name + ": missing dwellings repository.";
+                return false;
+            }
             return true;
         }
     }

--- a/ILUTE/Model/Housing/Validation/SaveAvgDwellingPriceByZone.cs
+++ b/ILUTE/Model/Housing/Validation/SaveAvgDwellingPriceByZone.cs
@@ -103,6 +103,11 @@ namespace TMG.Ilute.Model.Housing.Validation
 
         public bool RuntimeValidation(ref string error)
         {
+            if (Dwellings == null)
+            {
+                error = Name + ": missing dwellings repository.";
+                return false;
+            }
             return true;
         }
 


### PR DESCRIPTION
## Summary
- guard against missing household and dwelling repositories during initialization
- rename misnamed divorce methods
- avoid divide-by-zero in yearly divorce results
- fix object disposal for the Divorce model
- remove duplicate property in project config
- add runtime validation for births, deaths, and marriage routines

## Testing
- `dotnet build ILUTE/Ilute.csproj -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684739a0d43083208a801c5107007a79