### PR TITLE
Improve Repository.GetRepository null handling

### DIFF
--- a/ILUTE/Data/Repository.cs
+++ b/ILUTE/Data/Repository.cs
@@ -49,6 +49,10 @@ namespace TMG.Ilute.Data
         /// <returns>The now loaded data source's data</returns>
         public static T GetRepository<T>(IDataSource<T> source)
         {
+            if (source == null)
+            {
+                throw new XTMFRuntimeException(typeof(Repository), "Null data source passed to GetRepository");
+            }
             if (!source.Loaded)
             {
                 source.LoadData();


### PR DESCRIPTION
## Summary
- guard against null data sources in `Repository.GetRepository`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849987b2e808320851da240167880ff